### PR TITLE
fix: increased timeout for book command and fixed terminal focusing for linux

### DIFF
--- a/warrior_bot/commands/book/__init__.py
+++ b/warrior_bot/commands/book/__init__.py
@@ -337,7 +337,25 @@ def book(ctx: click.Context, building: tuple[str, ...], headed: bool):
         except Exception:
             pass
 
-    def _focus_terminal() -> None:
+    def _get_linux_terminal_window_id() -> str | None:
+        """Get the current active window ID on Linux before browser launches."""
+        if sys.platform == "darwin":
+            return None
+        try:
+            result = subprocess.run(
+                ["xdotool", "getactivewindow"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+            window_id = result.stdout.strip()
+            if window_id:
+                return window_id
+        except Exception:
+            pass
+        return None
+
+    def _focus_terminal(saved_window_id: str | None = None) -> None:
         """Bring the owning terminal back to the foreground."""
         if sys.platform == "darwin":
             target = _get_terminal_app()
@@ -350,17 +368,20 @@ def book(ctx: click.Context, building: tuple[str, ...], headed: bool):
             except Exception:
                 pass
         else:
-            try:
-                subprocess.run(
-                    ["xdotool", "getactivewindow", "windowactivate"],
-                    capture_output=True,
-                    timeout=3,
-                )
-            except Exception:
-                pass
+            if saved_window_id:
+                try:
+                    subprocess.run(
+                        ["xdotool", "windowactivate", saved_window_id],
+                        capture_output=True,
+                        timeout=3,
+                    )
+                except Exception:
+                    pass
 
     _step("Starting EMS Room Booking")
     _info("Press Ctrl+C at any time to abort.")
+
+    linux_terminal_window_id = _get_linux_terminal_window_id()
 
     with sync_playwright() as pw:
         launch_args = [
@@ -383,7 +404,7 @@ def book(ctx: click.Context, building: tuple[str, ...], headed: bool):
 
         if not headed:
             _minimize_browser(page)
-            _focus_terminal()
+            _focus_terminal(linux_terminal_window_id)
 
         building_query = " ".join(building).strip() or None
 

--- a/warrior_bot/commands/book/ems_pages.py
+++ b/warrior_bot/commands/book/ems_pages.py
@@ -376,7 +376,7 @@ def scrape_rooms(page: Page) -> list[dict[str, Any]]:
 
     page.wait_for_selector(
         "table#available-list tbody tr, .dynamic-filter-item-add",
-        timeout=10_000,
+        timeout=30_000,
     )
 
     rows = page.locator("table#available-list tbody tr")


### PR DESCRIPTION


Added _get_linux_terminal_window_id() to capture the terminal window ID before the browser launches Modified _focus_terminal() to accept and use the saved window ID on Linux The window ID is now captured before sync_playwright() starts and passed to _focus_terminal() after minimizing the browser

To test my changes, run the following command:

```bash
git checkout <branch-name>
```

Then, you can run:
```bash
pip install -e .
```

and test the command.

closes #58 