### PR TITLE
fix: omit the parsing of `-s` flag and infer search type by name

### DIFF
--- a/warrior_bot/commands/where/__init__.py
+++ b/warrior_bot/commands/where/__init__.py
@@ -107,8 +107,19 @@ def where(ctx, name, building, staff, restaurants, campus, awd, email):
                 )
     else:
         query = " ".join(name)
-        result, _ = facade.search_all(query)
+        result, found = facade.search_all(query)
         click.echo(result)
+
+        if found and email:
+            clean_result = re.sub(r"\x1b\[[0-9;]*m", "", result)
+            match = re.search(
+                r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", clean_result
+            )
+            professor_email = match.group(0) if match else None
+
+            if professor_email:
+                click.echo(f"Opening mail app for: {professor_email}")
+                _open_mail(professor_email)
 
     click.echo(f"Command took {round(time.time() - start_time, 2)} seconds")
 

--- a/warrior_bot/commands/where/where_facade.py
+++ b/warrior_bot/commands/where/where_facade.py
@@ -75,7 +75,7 @@ class WhereFacade:
         return self._format_building_list(results), True
 
     def search_all(self, query: str) -> tuple[str, bool]:
-        """Search across buildings, restaurants, and details."""
+        """Search across buildings, restaurants, staff, and details."""
         sections: list[str] = []
 
         buildings = self._building_fetcher.search(query)
@@ -89,6 +89,10 @@ class WhereFacade:
                     f"Restaurants matching '{query}'", restaurants
                 )
             )
+
+        staff_result, staff_found = self.search_staff(query.title())
+        if staff_found:
+            sections.append(staff_result)
 
         if sections:
             return "\n".join(sections), True


### PR DESCRIPTION
To test my changes, run the following command:

```bash
git checkout <branch-name>
```

Then, you can run:
```bash
pip install -e .
```

and test the command.

This will allow us to omit the `-s` flag. If a user forgets to pass it, we should still send their query because they very likely meant to search for a staff member
